### PR TITLE
Fixing inference of real type

### DIFF
--- a/src/Chimera.cpp
+++ b/src/Chimera.cpp
@@ -19,7 +19,6 @@
 
 using json = nlohmann::json;
 bool debug = false;
-bool printSeed = false;
 
 static constexpr char separator = '~';
 
@@ -91,7 +90,7 @@ static std::unique_ptr<Node> getNodeOrFail(const std::string &productionName,
 static std::unique_ptr<Node> buildSyntaxTree(
     const std::unordered_map<std::string, std::unordered_map<std::string, int>>
         &map,
-    const int n, std::mt19937 gen) {
+    const int n, std::mt19937& gen) {
 
   auto head = classMap["source_text"]("source_text");
   head->setParent(nullptr);
@@ -507,7 +506,7 @@ static cxxopts::ParseResult parseArgs(int argc, char **argv) {
 bool generateProgram(
     int n,
     std::unordered_map<std::string, std::unordered_map<std::string, int>> map,
-    std::unique_ptr<Node> &head, std::mt19937 gen) {
+    std::unique_ptr<Node> &head, std::mt19937& gen) {
 
   head = buildSyntaxTree(map, n, gen);
 
@@ -554,8 +553,8 @@ int main(int argc, char **argv) {
   if (flags.count("debug"))
     debug = true;
 
-  if (flags.count("printseed"))
-    printSeed = true;
+  bool printSeed = flags.count("printseed") != 0;
+  bool verbose = flags.count("verbose") != 0;
 
   std::ifstream f(flags["file"].as<std::string>());
 
@@ -583,14 +582,22 @@ int main(int argc, char **argv) {
     seed = rd();
   }
 
+  unsigned int finalSeed = seed;
   do {
-    if (printSeed) {
-      std::cerr << "Seed: " << seed << std::endl;
-    }
     std::mt19937 gen(seed);
     generatedCorrectProgram = generateProgram(n, map, head, gen);
+    if (verbose && printSeed) {
+      std::cerr << "Seed: " << seed << std::endl;
+    }
+
+    if (allow || generatedCorrectProgram)
+      finalSeed = seed;
+
     seed = rd();
   } while (!allow && !generatedCorrectProgram);
+
+  if (printSeed)
+    std::cout << "// Seed: " << finalSeed << "\n";
 
   if (flags.count("printtree"))
     dumpSyntaxTree(head.get());

--- a/src/TypeInference.cpp
+++ b/src/TypeInference.cpp
@@ -300,7 +300,7 @@ constraintSet TypeInferenceVisitor::visit(Dpi_import_item *node, typeId type) {
 }
 
 constraintSet TypeInferenceVisitor::visit(Tk_realtime *node, typeId type) {
-  auto t = static_cast<typeId>(CanonicalTypes::FLOAT_SCALAR);
+  auto t = static_cast<typeId>(CanonicalTypes::SCALAR);
   return constraintSet({{t, type}});
 }
 

--- a/src/TypeInference.cpp
+++ b/src/TypeInference.cpp
@@ -266,7 +266,8 @@ constraintSet TypeInferenceVisitor::visit(List_of_port_identifiers *node,
 }
 
 constraintSet TypeInferenceVisitor::visit(Non_integer_type *node, typeId type) {
-  return defaultVisitor(node, type);
+  auto t = static_cast<typeId>(CanonicalTypes::FLOAT_SCALAR);
+  return constraintSet({{t, type}});
 }
 
 constraintSet TypeInferenceVisitor::visit(Parameter_value_ranges_opt *node,


### PR DESCRIPTION
Addresses issue #4 

The fix for now is to avoid inferring the `real` type for Tk_realtime. We can eventually implement it as a `real` literal in the future.