### PR TITLE
Assign to non variable

### DIFF
--- a/scripts/run_experiments.sh
+++ b/scripts/run_experiments.sh
@@ -1,0 +1,21 @@
+
+PATH_CHIMERA="../../build/Chimera"
+PATH_SCRIPTS="../../scripts/"
+PATH_JSON="../../json/"
+NAME_JSON="gram_size_test.json"
+
+# mkdir generated_programs -p
+ cd generated_programs
+# rm -rf *
+# for i in 1 2 3 4 5 6
+# do
+#     mkdir "${i}gram"
+#     cd "${i}gram"
+#     echo "Running for ${i}gram"
+#     eval "${PATH_SCRIPTS}generate_programs.sh . ${PATH_CHIMERA} ${PATH_JSON}${i}${NAME_JSON} ${i} 1000 ${PATH_SCRIPTS}verible-verilog-format 2>output.txt"
+#     jg -allow_unsupported_OS -batch ../../scripts/attempt_synthesis.tcl -define target_dir "./invalid_programs" -define database_dir "." 1>/dev/null 2>&1
+#     cd ..
+# done
+cd ../scripts 
+python3 ngram_experiments.py result.csv ./verible-verilog-syntax 
+

--- a/src/Chimera.cpp
+++ b/src/Chimera.cpp
@@ -568,10 +568,8 @@ bool generateProgram(
     
     addConstantIDsToParameterList(m, declMap, dirMap);
 
-    auto isProgramCorrect = inferTypes(m);
-    if (!isProgramCorrect) {
-      isCorrect = false;
-    }
+    isCorrect = inferTypes(m);
+    
     
   }
 

--- a/src/Chimera.cpp
+++ b/src/Chimera.cpp
@@ -565,11 +565,14 @@ bool generateProgram(
     int lastID = renameVars(m, n, modID++, declMap);
 
     replaceTypes(m, lastID);
+    
+    addConstantIDsToParameterList(m, declMap, dirMap);
+
     auto isProgramCorrect = inferTypes(m);
     if (!isProgramCorrect) {
       isCorrect = false;
     }
-    addConstantIDsToParameterList(m, declMap, dirMap);
+    
   }
 
   declMap.clear();

--- a/src/TypeInference.cpp
+++ b/src/TypeInference.cpp
@@ -500,7 +500,7 @@ constraintSet TypeInferenceVisitor::visit(
 
 constraintSet TypeInferenceVisitor::visit(Module_parameter_port_list_opt *node,
                                           typeId type) {
-  return defaultVisitor(node, type);
+  return defaultVisitor(node, type); //static_cast<typeId>(CanonicalTypes::CONST_SCALAR));
 }
 
 constraintSet TypeInferenceVisitor::visit(Property_prefix_expr *node,

--- a/src/TypeInference.cpp
+++ b/src/TypeInference.cpp
@@ -499,7 +499,7 @@ constraintSet TypeInferenceVisitor::visit(
 }
 
 constraintSet TypeInferenceVisitor::visit(Module_parameter_port_list_opt *node,
-                                          typeId type) {
+                                          typeId) {
   return defaultVisitor(node, static_cast<typeId>(CanonicalTypes::CONST_SCALAR));
 }
 

--- a/src/TypeInference.cpp
+++ b/src/TypeInference.cpp
@@ -500,7 +500,7 @@ constraintSet TypeInferenceVisitor::visit(
 
 constraintSet TypeInferenceVisitor::visit(Module_parameter_port_list_opt *node,
                                           typeId type) {
-  return defaultVisitor(node, type); //static_cast<typeId>(CanonicalTypes::CONST_SCALAR));
+  return defaultVisitor(node, static_cast<typeId>(CanonicalTypes::CONST_SCALAR));
 }
 
 constraintSet TypeInferenceVisitor::visit(Property_prefix_expr *node,


### PR DESCRIPTION
Fix the assignment to a non-variable by inferring it as a const scalar, the program should be rejected during type inference.