### PR TITLE
fixing incorrect parameter creation

### DIFF
--- a/src/Chimera.cpp
+++ b/src/Chimera.cpp
@@ -374,7 +374,6 @@ static void createParameterList(Node *parameterList) {
   std::vector<std::unique_ptr<Node>> children;
 
   children.push_back(std::make_unique<Terminal>(" #( "));
-  children.push_back(std::make_unique<Terminal>(" ) "));
 
   parameterList->setChildren(std::move(children));
 }


### PR DESCRIPTION
The change from this [PR](https://github.com/lac-dcc/chimera/pull/26) caused incorrect parameter creation, closing the `module` parenthesis before listing the parameters: 
```verilog
 module  module_0 #(  ) 
parameter id_3 =32'd58,
parameter id_4 =32'd69,
parameter id_5 =32'd67)
```
This PR fix this issue by deleting the line that closes the parenthesis before adding the parameters nodes.