### PR TITLE
Add bit and wire equivalents

### DIFF
--- a/src/TypeInference.cpp
+++ b/src/TypeInference.cpp
@@ -87,6 +87,9 @@ bool inferTypes(Node *head) {
   // replace infered types
 
   bool isCorrect = true;
+  std::vector<std::string> wireEquivalents = {
+      " wire ",    " tri ",     " tri0 ", " tri1 ",
+      " supply0 ", " supply1 ", " wor ",  " wand "};
 
   for (auto &[type, eqTypes] : eq) {
 
@@ -112,31 +115,8 @@ bool inferTypes(Node *head) {
 
           case CanonicalTypes::VECTOR:
           case CanonicalTypes::WIRE:
-            n->setElement(" wire ");
-            break;
-          case CanonicalTypes::TRI:
-            n->setElement(" tri ");
-            break;
-          case CanonicalTypes::TRI0:
-            n->setElement(" tri0 ");
-            break;
-          case CanonicalTypes::TRI1:
-            n->setElement(" tri1 ");
-            break;
-          case CanonicalTypes::SUPPLY0:
-            n->setElement(" supply0 ");
-            break;
-          case CanonicalTypes::SUPPLY1:
-            n->setElement(" supply1 ");
-            break;
-          case CanonicalTypes::WOR:
-            n->setElement(" wor ");
-            break;
-          case CanonicalTypes::WAND:
-            n->setElement(" wand ");
-            break;
-          case CanonicalTypes::UWIRE:
-            n->setElement(" uwire ");
+            // selecting a random net_type
+            n->setElement(wireEquivalents[rand() % wireEquivalents.size()]);
             break;
           case CanonicalTypes::BIT:
             n->setElement(" bit ");

--- a/src/TypeInference.cpp
+++ b/src/TypeInference.cpp
@@ -88,8 +88,8 @@ bool inferTypes(Node *head) {
 
   bool isCorrect = true;
   std::vector<std::string> wireEquivalents = {
-      " wire ",    " tri ",     " tri0 ", " tri1 ",
-      " supply0 ", " supply1 ", " wor ",  " wand "};
+      " wire ",    " tri ", " tri0 ", " tri1 ", " supply0 ",
+      " supply1 ", " wor ", " wand ", " uwire "};
 
   for (auto &[type, eqTypes] : eq) {
 

--- a/src/TypeInference.cpp
+++ b/src/TypeInference.cpp
@@ -114,6 +114,30 @@ bool inferTypes(Node *head) {
           case CanonicalTypes::WIRE:
             n->setElement(" wire ");
             break;
+          case CanonicalTypes::TRI:
+            n->setElement(" tri ");
+            break;
+          case CanonicalTypes::TRI0:
+            n->setElement(" tri0 ");
+            break;
+          case CanonicalTypes::TRI1:
+            n->setElement(" tri1 ");
+            break;
+          case CanonicalTypes::SUPPLY0:
+            n->setElement(" supply0 ");
+            break;
+          case CanonicalTypes::SUPPLY1:
+            n->setElement(" supply1 ");
+            break;
+          case CanonicalTypes::WOR:
+            n->setElement(" wor ");
+            break;
+          case CanonicalTypes::WAND:
+            n->setElement(" wand ");
+            break;
+          case CanonicalTypes::UWIRE:
+            n->setElement(" uwire ");
+            break;
           case CanonicalTypes::BIT:
             n->setElement(" bit ");
             break;

--- a/src/TypeInference.cpp
+++ b/src/TypeInference.cpp
@@ -115,7 +115,8 @@ bool inferTypes(Node *head) {
             n->setElement(" wire ");
             break;
           case CanonicalTypes::BIT:
-
+            n->setElement(" bit ");
+            break;
           case CanonicalTypes::SCALAR:
           case CanonicalTypes::CONST_SCALAR:
           case CanonicalTypes::LOGIC:

--- a/src/TypeInference.h
+++ b/src/TypeInference.h
@@ -28,6 +28,14 @@ enum class CanonicalTypes : typeId {
   STRING,
   REG,
   WIRE,
+  TRI,
+  TRI0,
+  TRI1,
+  SUPPLY0,
+  SUPPLY1,
+  WOR,
+  WAND,
+  UWIRE,
   FIRST_FRESH_TYPE // Marks the size of CanonicalTypes. Not meant to be used.
 };
 

--- a/src/TypeInference.h
+++ b/src/TypeInference.h
@@ -28,14 +28,6 @@ enum class CanonicalTypes : typeId {
   STRING,
   REG,
   WIRE,
-  TRI,
-  TRI0,
-  TRI1,
-  SUPPLY0,
-  SUPPLY1,
-  WOR,
-  WAND,
-  UWIRE,
   FIRST_FRESH_TYPE // Marks the size of CanonicalTypes. Not meant to be used.
 };
 


### PR DESCRIPTION
- Addition of the bit type in the type inference
- Creation of new CanonicalTypes which represent other variations of "net_type"(TRI, TRI0, TRI1, SUPPLY0, SUPPLY1, WOR, WAND, UWIRE) 
