### PR TITLE
Fixing error: "id_1 is not a constant"

### DIFF
--- a/src/IdentifierRenamingVisitor.h
+++ b/src/IdentifierRenamingVisitor.h
@@ -23,6 +23,7 @@ class IdentifierRenamingVisitor : public Visitor<void> {
 public:
   enum ContextType {
     EXPR = 0,
+    CONSTANT_EXPR,
     DECL,
     DECL_CONSTANT,
     MODULE,
@@ -110,8 +111,11 @@ public:
   virtual void visit(Udp_port_decls *node) override;
 
   virtual void visit(Label_opt *node) override;
+
   virtual void visit(Function_declaration *node) override;
 
   virtual void visit(Any_param_declaration *node) override;
+
+  virtual void visit(Parameter_expr *node) override;
 };
 #endif


### PR DESCRIPTION
In the last experiment, we had a lot of this type of error: 
```
'id_1' is not a constant
```
This error happens when you try to assign a variable that is not a constant to a constant variable, for instance: 
```verilog
input wire id_0; 
localparam id1 = id_0
```
In this PR, parameters and localparams can only be assigned to other parameters or localparams. If there are not available variables, we assign it to a constant value. 