### PR TITLE
Implement DOTGenVisitor to generate DOT representation of AST

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 
 set(CMAKE_CXX_STANDARD 20 CACHE STRING "")
 
-add_executable(Chimera Chimera.cpp AST.cpp CodeGenVisitor.cpp ConstantsReplacerVisitor.cpp IdentifierRenamingVisitor.cpp TypeInference.cpp ReachingDefs.cpp)
+add_executable(Chimera Chimera.cpp AST.cpp CodeGenVisitor.cpp ConstantsReplacerVisitor.cpp IdentifierRenamingVisitor.cpp TypeInference.cpp ReachingDefs.cpp DOTGenVisitor.cpp)
 
 target_link_libraries(Chimera PRIVATE nlohmann_json::nlohmann_json)
 target_link_libraries(Chimera PRIVATE cxxopts::cxxopts)

--- a/src/Chimera.cpp
+++ b/src/Chimera.cpp
@@ -593,7 +593,7 @@ static void writeSyntaxTreeToDOT(Node *head, const std::string &fileName) {
 static cxxopts::ParseResult parseArgs(int argc, char **argv) {
   // clang-format off
   cxxopts::Options options("Chimera", "Generates SystemVerilog Programs based on a json file of probabilities.");
-  options.positional_help("<file> <n-value> [options]");
+  options.positional_help("[options] <file> <n-value>");
 
   options.add_options()
     ("file", "JSON file with n-gram probabilities", cxxopts::value<std::string>())

--- a/src/Chimera.cpp
+++ b/src/Chimera.cpp
@@ -641,11 +641,6 @@ static cxxopts::ParseResult parseArgs(int argc, char **argv) {
     exit(1);
   }
 
-  if(!flags.count("visualisetree")) {
-    std::cerr << "Visualise tree missing." << std::endl;
-    exit(1);
-  }
-
   return flags;
 }
 PortDir currentDir = PortDir::INPUT;
@@ -1470,8 +1465,6 @@ int main(int argc, char **argv) {
     }
   }
 
-  std::cout << "Vistree: " << flags.count("visualisetree") << std::endl;
-  
   for (const auto &m : usedModules) {
     if (flags.count("printtree"))
       dumpSyntaxTree(m->moduleHead.get());

--- a/src/DOTGenVisitor.cpp
+++ b/src/DOTGenVisitor.cpp
@@ -11,7 +11,7 @@ DotNode DOTGenVisitor::visit(Node *node) {
     auto nodeName = this->generateNodeName();
     DotNode dotNode;
     dotNode.name = nodeName;
-    dotNode.label = node->getElement();
+    dotNode.label = (node->getElement().length() == 0 ? "_empty" : node->getElement());
     this->terminals.push_back(dotNode);
     return dotNode;
   } else {

--- a/src/DOTGenVisitor.cpp
+++ b/src/DOTGenVisitor.cpp
@@ -11,7 +11,7 @@ DotNode DOTGenVisitor::visit(Node *node) {
     auto nodeName = this->generateNodeName();
     DotNode dotNode;
     dotNode.name = nodeName;
-    dotNode.label = (node->getElement().length() == 0 ? "_empty" : node->getElement());
+    dotNode.label = (node->getElement().empty() ? "_empty" : node->getElement());
     this->terminals.push_back(dotNode);
     return dotNode;
   } else {

--- a/src/DOTGenVisitor.cpp
+++ b/src/DOTGenVisitor.cpp
@@ -1,0 +1,67 @@
+#include "DOTGenVisitor.h"
+#include <fstream>
+#include <iostream>
+
+std::string DOTGenVisitor::generateNodeName() {
+  return "n_" + std::to_string(this->nodeCounter++);
+}
+
+DotNode DOTGenVisitor::visit(Node *node) {
+  if (node->getChildren().empty()) {
+    auto nodeName = this->generateNodeName();
+    DotNode dotNode;
+    dotNode.name = nodeName;
+    dotNode.label = node->getElement();
+    this->terminals.push_back(dotNode);
+    return dotNode;
+  } else {
+    auto nodeName = this->generateNodeName();
+    DotNode dotNode;
+    dotNode.name = nodeName;
+    dotNode.label = node->getElement();
+    this->nonTerminals.push_back(dotNode);
+    for (const std::unique_ptr<Node> &child : node->getChildren()) {
+      auto childNode = this->visit(child.get());
+      this->edges.push_back(dotNode.name + " -> " + childNode.name);
+    }
+    return dotNode;
+  }
+}
+
+std::string DOTGenVisitor::generateDOT() {
+  std::string dotSrc = "digraph G {\n";
+  dotSrc += "\tnode [shape=circle];\n";
+  dotSrc += "\tedge [color=\"#333333\"];\n\n";
+
+  if(!this->nonTerminals.empty()) {
+    for (size_t i = 0; i < this->nonTerminals.size() - 1; i++) {
+        dotSrc += "\t" + this->nonTerminals[i].name + "[label=\"" + this->nonTerminals[i].label + "\"];\n";
+    }
+    auto lastIndex = this->nonTerminals.size() - 1;
+    dotSrc += "\t" + this->nonTerminals[lastIndex].name + "[label=\"" + this->nonTerminals[lastIndex].label + "\"];\n";
+  }
+
+  if(!this->terminals.empty()) {
+    for (size_t i = 0; i < this->terminals.size() - 1; i++) {
+        dotSrc += "\t" + this->terminals[i].name + "[label=\"" + this->terminals[i].label + "\"];\n";
+    }
+    auto lastIndex = this->terminals.size() - 1;
+    dotSrc += "\t" + this->terminals[lastIndex].name + "[label=\"" + this->terminals[lastIndex].label + "\"];\n";
+  }
+
+  for (const std::string &edge : this->edges) {
+    dotSrc += "\t" + edge + ";\n";
+  }
+  dotSrc += "}\n";
+  return dotSrc;
+}
+
+void DOTGenVisitor::writeToFile(const std::string &fileName) {
+  std::ofstream file(fileName);
+  if(file.is_open()) {
+    file << this->generateDOT();
+    file.close();
+  } else {
+    std::cerr << "Error: Unable to open file for writing DOT: " << fileName << std::endl;
+  }
+}

--- a/src/DOTGenVisitor.h
+++ b/src/DOTGenVisitor.h
@@ -1,0 +1,29 @@
+#ifndef CHIMERA_DOT_GEN_VISITOR_H
+#define CHIMERA_DOT_GEN_VISITOR_H
+#include "AST.h"
+#include "Visitor.h"
+
+class DotNode {
+  public:
+    std::string name;
+    std::string label;
+};
+
+/**
+ * @class DOTGenVisitor
+ * @brief Visitor for generating DOT representation from the AST.
+ */
+class DOTGenVisitor : public Visitor<DotNode> {
+private:
+  std::string dotSrc;
+  std::vector<DotNode> nonTerminals, terminals;
+  std::vector<std::string> edges;
+
+  int nodeCounter = 0;
+  std::string generateNodeName();
+public:
+  virtual void writeToFile(const std::string &fileName);
+  virtual std::string generateDOT();
+  virtual DotNode visit(Node *node) override;
+};
+#endif


### PR DESCRIPTION
Closes: #66 

* Adds a new visitor: `DOTGenVisitor.cpp` which visits the AST and creates terminal, non-terminals and edge representations for DOT
* If `visualisetree` option is provided then it writes the DOT representation to a file

To test, run (after building Chimera):

```bash
./build/Chimera --visualisetree json/1gram_test.json 1 > program.v
```