### PR TITLE
Fix not declared variables

### DIFF
--- a/src/Chimera.cpp
+++ b/src/Chimera.cpp
@@ -1415,9 +1415,8 @@ int main(int argc, char **argv) {
                   if (!val.empty()) {
                     if (pcfg)
                       dotcfg << m2->moduleName->getElement() << " -> "
-                             << m->moduleName->getElement()
-                             << "[ label = " << " "
-                             << m->moduleName->getElement() << " ]\n";
+                             << m->moduleName->getElement() << "[ label = "
+                             << " " << m->moduleName->getElement() << " ]\n";
                     hierarchicalReference(
                         pp2.programPoint->getParent(), getPosFromPP(pp2) + 1,
                         id_call, val, pp2.scope, m->moduleName->getElement());

--- a/src/IdentifierRenamingVisitor.cpp
+++ b/src/IdentifierRenamingVisitor.cpp
@@ -521,3 +521,11 @@ void IdentifierRenamingVisitor::visit(Parameter_expr *node) {
   }
   finishIDContext();
 }
+
+void IdentifierRenamingVisitor::visit(Parameter_override *node) {
+  createIDContext(ContextType::CONSTANT_EXPR);
+  for (const std::unique_ptr<Node> &child : node->getChildren()) {
+    this->applyVisit(child.get());
+  }
+  finishIDContext();
+}

--- a/src/IdentifierRenamingVisitor.h
+++ b/src/IdentifierRenamingVisitor.h
@@ -118,5 +118,7 @@ public:
   virtual void visit(Any_param_declaration *node) override;
 
   virtual void visit(Parameter_expr *node) override;
+
+  virtual void visit(Parameter_override *node) override;
 };
 #endif

--- a/src/IdentifierRenamingVisitor.h
+++ b/src/IdentifierRenamingVisitor.h
@@ -33,13 +33,14 @@ public:
     ASSIGNMENT
   };
 
+  std::vector<std::shared_ptr<Var>> to_define; // vars used but not declared
+
 private:
   std::string defId = "";
   std::string defType = "";
 
   std::stack<ContextType> contexts;
   std::vector<std::shared_ptr<Var>> identifiers; // vars declared
-  std::vector<std::shared_ptr<Var>> to_define;   // vars used but not declared
   std::stack<std::size_t> scopeLimit;
   bool isStartingToken(std::string t);
   bool isFinishingToken(std::string t);


### PR DESCRIPTION
The easiest way I found to prevent the use of undeclared variables was to check whether it was happening. This increased the percentage of correct programs. However, we still have an issue in the program below:
```verilog
  id_10(
      1, 1, id_7
  );
  assign id_10 = id_2;
```
In this case, Jasper reports that id_10 is not declared.