### PR TITLE
Fix non-ansi ports matching

### DIFF
--- a/src/Chimera.cpp
+++ b/src/Chimera.cpp
@@ -281,7 +281,7 @@ static bool matchNonAnsiPorts(
         break;
       }
 
-      auto childId = std::make_unique<Terminal>(id);
+      auto childId = std::make_unique<Symbolidentifier>(id);
       dir_map[id] = childId.get();
 
       auto childDir = std::make_unique<Terminal>(dir);

--- a/src/Chimera.cpp
+++ b/src/Chimera.cpp
@@ -1407,9 +1407,8 @@ int main(int argc, char **argv) {
                   if (!val.empty()) {
                     if (pcfg)
                       dotcfg << m2->moduleName->getElement() << " -> "
-                             << m->moduleName->getElement()
-                             << "[ label = " << " "
-                             << m->moduleName->getElement() << " ]\n";
+                             << m->moduleName->getElement() << "[ label = "
+                             << " " << m->moduleName->getElement() << " ]\n";
                     hierarchicalReference(
                         pp2.programPoint->getParent(), getPosFromPP(pp2) + 1,
                         id_call, val, pp2.scope, m->moduleName->getElement());


### PR DESCRIPTION
closes #86 
Modify non-ansi ports matching to fix the type inference pass on them.