### PR TITLE
Fixing 'id is not a constant' error in if cases

### DIFF
--- a/src/IdentifierRenamingVisitor.cpp
+++ b/src/IdentifierRenamingVisitor.cpp
@@ -309,7 +309,9 @@ void IdentifierRenamingVisitor::visit(Expression *node) {
     this->applyVisit(child.get());
   }
 
-  finishIDContext();
+  if (!contexts.empty() && contexts.top() != ContextType::CONSTANT_EXPR) {
+    finishIDContext();
+  }
 }
 
 void IdentifierRenamingVisitor::visit(Symbolidentifier *node) {
@@ -523,6 +525,14 @@ void IdentifierRenamingVisitor::visit(Parameter_expr *node) {
 }
 
 void IdentifierRenamingVisitor::visit(Parameter_override *node) {
+  createIDContext(ContextType::CONSTANT_EXPR);
+  for (const std::unique_ptr<Node> &child : node->getChildren()) {
+    this->applyVisit(child.get());
+  }
+  finishIDContext();
+}
+
+void IdentifierRenamingVisitor::visit(Expression_in_parens *node) {
   createIDContext(ContextType::CONSTANT_EXPR);
   for (const std::unique_ptr<Node> &child : node->getChildren()) {
     this->applyVisit(child.get());

--- a/src/IdentifierRenamingVisitor.h
+++ b/src/IdentifierRenamingVisitor.h
@@ -30,7 +30,7 @@ public:
     DEFINING_ID,
     DEFINING_TYPE,
     TYPE_DECL,
-    ASSIGNMENT
+    ASSIGNMENT,
   };
 
   std::vector<std::shared_ptr<Var>> to_define; // vars used but not declared
@@ -120,5 +120,7 @@ public:
   virtual void visit(Parameter_expr *node) override;
 
   virtual void visit(Parameter_override *node) override;
+
+  virtual void visit(Expression_in_parens *node) override;
 };
 #endif


### PR DESCRIPTION
The `id is not a constant` error also occurred inside if statements. The expression inside the parentheses of the if must be a constant; otherwise, Jasper throws this error.