### PR TITLE
Fixing "syntax error near ','"

### DIFF
--- a/src/Chimera.cpp
+++ b/src/Chimera.cpp
@@ -828,6 +828,18 @@ static void removeIncorrectGates(Node *head) {
   }
 }
 
+static void removeIncorrectParameters(Node *head) {
+  // Remove gates declarations from the generated module
+  if (head->type == NodeType::PARAMETER_VALUE_OPT) {
+    head->clearChildren();
+    head->insertChildToEnd(std::make_unique<Terminal>(""));
+  }
+
+  for (size_t i = 0; i < head->getChildren().size(); i++) {
+    removeIncorrectParameters(head->getChildren()[i].get());
+  }
+}
+
 static void generateModules(
     int n,
     std::unordered_map<std::string, std::unordered_map<std::string, int>> map,
@@ -837,6 +849,7 @@ static void generateModules(
   head = buildSyntaxTree(map, n, gen);
 
   removeIncorrectGates(head.get());
+  removeIncorrectParameters(head.get());
 
   std::vector<Node *> moduleHeads, portDeclarations;
   findModulePorts(head.get(), moduleHeads, portDeclarations);


### PR DESCRIPTION
The error `syntax error near ','` occurred because Verible's grammar incorrectly allowed parameters to be created when declaring an ID. This was due to a single rule, `PARAMETER_VALUE_OPT`, which permitted these invalid parameters. This PR fixes the issue by removing the children from this rule.