### PR TITLE
fix : circular Net_declaration , Circular cont_assign

### DIFF
--- a/src/IdentifierRenamingVisitor.cpp
+++ b/src/IdentifierRenamingVisitor.cpp
@@ -4,6 +4,9 @@
 
 std::string last_id_name_created = "";
 std::set<std::string> constant_names;
+bool prevAssign=false;
+std::string prevAssignId="";
+
 
 IdentifierRenamingVisitor::IdentifierRenamingVisitor(
     int modID, std::unordered_map<std::string, Node *> &declMap,
@@ -185,6 +188,14 @@ std::string IdentifierRenamingVisitor::findID(std::string type) {
            (*id)->name == last_id_name_created)) {
         continue;
       }
+      if(isExpr && (*id)->name==last_id_name_created) continue;
+
+      if(prevAssign && (*id)->name==prevAssignId) 
+      {
+	      prevAssign=false;
+	      prevAssignId="";
+	      continue;
+      }
       std::stack<std::string> stackName;
       auto curr = *id;
       stackName.push(curr->name);
@@ -238,6 +249,11 @@ std::string IdentifierRenamingVisitor::findID(std::string type) {
   if (debug)
     std::cerr << "Using var: " << options[c] << std::endl;
 
+  if(isAssign)
+  {
+	  prevAssign=true;
+	  prevAssignId = options[c];
+  }
   return options[c];
 }
 

--- a/src/IdentifierRenamingVisitor.cpp
+++ b/src/IdentifierRenamingVisitor.cpp
@@ -4,9 +4,8 @@
 
 std::string last_id_name_created = "";
 std::set<std::string> constant_names;
-bool prevAssign=false;
-std::string prevAssignId="";
-
+bool prevAssign = false;
+std::string prevAssignId = "";
 
 IdentifierRenamingVisitor::IdentifierRenamingVisitor(
     int modID, std::unordered_map<std::string, Node *> &declMap,
@@ -188,13 +187,13 @@ std::string IdentifierRenamingVisitor::findID(std::string type) {
            (*id)->name == last_id_name_created)) {
         continue;
       }
-      if(isExpr && (*id)->name==last_id_name_created) continue;
+      if (isExpr && (*id)->name == last_id_name_created)
+        continue;
 
-      if(prevAssign && (*id)->name==prevAssignId) 
-      {
-	      prevAssign=false;
-	      prevAssignId="";
-	      continue;
+      if (prevAssign && (*id)->name == prevAssignId) {
+        prevAssign = false;
+        prevAssignId = "";
+        continue;
       }
       std::stack<std::string> stackName;
       auto curr = *id;
@@ -249,10 +248,9 @@ std::string IdentifierRenamingVisitor::findID(std::string type) {
   if (debug)
     std::cerr << "Using var: " << options[c] << std::endl;
 
-  if(isAssign)
-  {
-	  prevAssign=true;
-	  prevAssignId = options[c];
+  if (isAssign) {
+    prevAssign = true;
+    prevAssignId = options[c];
   }
   return options[c];
 }


### PR DESCRIPTION
PR resolves #104  
Circular Id  at 
1. ID creation (Node : Net_declaration)
2. assign ID (Node :cont_assign )