### PR TITLE
Fixing "single value range is not allowed" error

### DIFF
--- a/src/IdentifierRenamingVisitor.h
+++ b/src/IdentifierRenamingVisitor.h
@@ -168,5 +168,6 @@ public:
   virtual void visit(Type_identifier_followed_by_id *node) override;
 
   virtual void visit(Type_declaration *node) override;
+  virtual void visit(Reference *node) override;
 };
 #endif


### PR DESCRIPTION
This error was occurring in the declaration of variables, when there was a use of a range selection using only one value, like below:
```verilog 
logic [7:0][1] id_9
```

This PR fixes this issue by ensuring that while declaring variables, there is no single range being used. The acceptance rate in the analyze phase after this modification using Cadence's grammar is around 56%. 